### PR TITLE
Support output result to a string slice.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -35,6 +35,37 @@ func tokenToString(token *Token) (output string) {
 	return
 }
 
+// 输出分词结果到一个字符串slice
+//
+// 有两种输出模式，以"中华人民共和国"为例
+//
+//	普通模式（searchMode=false）输出一个分词"[中华人民共和国]"
+// 	搜索模式（searchMode=true） 输出普通模式的再细致切分：
+//		"[中华 人民 共和 共和国 人民共和国 中华人民共和国]"
+//
+// 搜索模式主要用于给搜索引擎提供尽可能多的关键字，详情请见Token结构体的注释。
+
+func SegmentsToSlice(segs []Segment, searchMode bool) (output []string) {
+	if searchMode {
+		for _, seg := range segs {
+			output = append(output, tokenToSlice(seg.token)...)
+		}
+	} else {
+		for _, seg := range segs {
+			output = append(output, seg.token.Text())
+		}
+	}
+	return
+}
+
+func tokenToSlice(token *Token) (output []string) {
+	for _, s := range token.segments {
+		output = append(output, tokenToSlice(s.token)...)
+	}
+	output = append(output, textSliceToString(token.text))
+	return output
+}
+
 // 将多个字元拼接一个字符串输出
 func textSliceToString(text []Text) string {
 	var output string


### PR DESCRIPTION
Python 的中文分词模块 (fxsjy/jieba, pymmesg) 可以用函数方便的把分词结果存在一个 list 中返回，我想在sego中也添加这样的函数，所以我在 SegmentsToString 的基础上增加了 SegmentsToSlice 来返回一个保存分词结果的 string slice 。
