### PR TITLE
修正两处注释对齐

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -8,9 +8,9 @@ import (
 //
 // 有两种输出模式，以"中华人民共和国"为例
 //
-//	普通模式（searchMode=false）输出一个分词"中华人民共和国/ns "
-// 	搜索模式（searchMode=true） 输出普通模式的再细致切分：
-//		"中华/nz 人民/n 共和/nz 共和国/ns 人民共和国/nt 中华人民共和国/ns "
+//  普通模式（searchMode=false）输出一个分词"中华人民共和国/ns "
+//  搜索模式（searchMode=true） 输出普通模式的再细致切分：
+//      "中华/nz 人民/n 共和/nz 共和国/ns 人民共和国/nt 中华人民共和国/ns "
 //
 // 搜索模式主要用于给搜索引擎提供尽可能多的关键字，详情请见Token结构体的注释。
 func SegmentsToString(segs []Segment, searchMode bool) (output string) {
@@ -39,9 +39,9 @@ func tokenToString(token *Token) (output string) {
 //
 // 有两种输出模式，以"中华人民共和国"为例
 //
-//	普通模式（searchMode=false）输出一个分词"[中华人民共和国]"
-// 	搜索模式（searchMode=true） 输出普通模式的再细致切分：
-//		"[中华 人民 共和 共和国 人民共和国 中华人民共和国]"
+//  普通模式（searchMode=false）输出一个分词"[中华人民共和国]"
+//  搜索模式（searchMode=true） 输出普通模式的再细致切分：
+//      "[中华 人民 共和 共和国 人民共和国 中华人民共和国]"
 //
 // 搜索模式主要用于给搜索引擎提供尽可能多的关键字，详情请见Token结构体的注释。
 


### PR DESCRIPTION
pull #3 里面提到的两处注释对齐，我以为是 github 的问题，然后给 github 发邮件问了下发现是代码里面 tab 和 space 混用造成的，把 tab 替换成 space 就对齐了。
