### PR TITLE
减少30%的内存占用

### DIFF
--- a/segmenter.go
+++ b/segmenter.go
@@ -245,7 +245,7 @@ func maxInt(a, b int) int {
 
 // 将文本划分成字元
 func splitTextToWords(text Text) []Text {
-	output := make([]Text, 0, len(text)/4)
+	output := make([]Text, 0, len(text)/8)
 	current := 0
 	inAlphanumeric := true
 	alphanumericStart := 0

--- a/segmenter.go
+++ b/segmenter.go
@@ -245,9 +245,8 @@ func maxInt(a, b int) int {
 
 // 将文本划分成字元
 func splitTextToWords(text Text) []Text {
-	output := make([]Text, len(text))
+	output := make([]Text, 0, len(text)/4)
 	current := 0
-	currentWord := 0
 	inAlphanumeric := true
 	alphanumericStart := 0
 	for current < len(text) {
@@ -262,12 +261,10 @@ func splitTextToWords(text Text) []Text {
 			if inAlphanumeric {
 				inAlphanumeric = false
 				if current != 0 {
-					output[currentWord] = toLower(text[alphanumericStart:current])
-					currentWord++
+					output = append(output, toLower(text[alphanumericStart:current]))
 				}
 			}
-			output[currentWord] = text[current : current+size]
-			currentWord++
+			output = append(output, text[current:current+size])
 		}
 		current += size
 	}
@@ -275,12 +272,11 @@ func splitTextToWords(text Text) []Text {
 	// 处理最后一个字元是英文的情况
 	if inAlphanumeric {
 		if current != 0 {
-			output[currentWord] = toLower(text[alphanumericStart:current])
-			currentWord++
+			output = append(output, toLower(text[alphanumericStart:current]))
 		}
 	}
 
-	return output[:currentWord]
+	return output
 }
 
 // 将英文词转化为小写


### PR DESCRIPTION
Hi，感谢开源这个分词库。
在使用过程中发现内存占用比较大，看了一下是 `splitTextToWords` 里面的 `slice` 开得太大了。
改了之后内存占用少了30%多。

对比：
之前
```
(pprof) top
280.15MB of 281.15MB total (99.64%)
Dropped 13 nodes (cum <= 1.41MB)
Showing top 10 nodes out of 15 (cum >= 4MB)
      flat  flat%   sum%        cum   cum%
  131.53MB 46.78% 46.78%   131.53MB 46.78%  github.com/adamzy/sego.splitTextToWords
      65MB 23.12% 69.90%   276.15MB 98.22%  github.com/adamzy/sego.(*Segmenter).LoadDictionary
   54.57MB 19.41% 89.31%    54.57MB 19.41%  github.com/adamzy/sego.upsert
   15.50MB  5.51% 94.83%    15.50MB  5.51%  github.com/adamzy/sego.(*Segmenter).segmentWords
       8MB  2.85% 97.67%        8MB  2.85%  fmt.(*ss).convertString
    5.55MB  1.97% 99.64%    60.11MB 21.38%  github.com/adamzy/sego.(*Dictionary).addToken
         0     0% 99.64%        8MB  2.85%  fmt.(*ss).doScan
         0     0% 99.64%        8MB  2.85%  fmt.(*ss).scanOne
         0     0% 99.64%        8MB  2.85%  fmt.Fscanln
         0     0% 99.64%        4MB  1.42%  github.com/adamzy/sego.(*Segmenter).Segment
```
现在
```
(pprof) top
183.56MB of 184.06MB total (99.73%)
Dropped 5 nodes (cum <= 0.92MB)
Showing top 10 nodes out of 12 (cum >= 183.56MB)
      flat  flat%   sum%        cum   cum%
      61MB 33.14% 33.14%   183.56MB 99.73%  github.com/adamzy/sego.(*Segmenter).LoadDictionary
   52.51MB 28.53% 61.67%    52.51MB 28.53%  github.com/adamzy/sego.upsert
   42.50MB 23.09% 84.76%    42.50MB 23.09%  github.com/adamzy/sego.splitTextToWords
      14MB  7.61% 92.37%       14MB  7.61%  github.com/adamzy/sego.(*Segmenter).segmentWords
       8MB  4.35% 96.71%        8MB  4.35%  fmt.(*ss).convertString
    5.55MB  3.01% 99.73%    58.05MB 31.54%  github.com/adamzy/sego.(*Dictionary).addToken
         0     0% 99.73%        8MB  4.35%  fmt.(*ss).doScan
         0     0% 99.73%        8MB  4.35%  fmt.(*ss).scanOne
         0     0% 99.73%        8MB  4.35%  fmt.Fscanln
         0     0% 99.73%   183.56MB 99.73%  main.main
```