### PR TITLE
Make segmenter load dictionary using github.com/wangkuiyi/fs

### DIFF
--- a/segmenter.go
+++ b/segmenter.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"os"
 	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/wangkuiyi/fs"
 )
 
 const (
@@ -45,7 +46,7 @@ func (seg *Segmenter) LoadDictionary(files string) {
 	seg.dict = NewDictionary()
 	for _, file := range strings.Split(files, ",") {
 		log.Printf("载入sego词典 %s", file)
-		dictFile, err := os.Open(file)
+		dictFile, err := fs.Open(file)
 		defer dictFile.Close()
 		if err != nil {
 			log.Fatalf("无法载入字典文件 \"%s\" \n", file)


### PR DESCRIPTION
Hi Hui, 

Thank you for this great work of Chinese tokenizer!

I am open sourcing [a distributed machine learning system](http://dl.acm.org/citation.cfm?id=2700497), where thousands of processes using your tokenizer run on hundreds of computers. To make it easy for those processes to load the dictionary, it would be great if we can load the dictionary from HDFS. Also, loading from local filesystem is important for testing purpose. So I wrote `github.com/wangkuiyi/fs` and propose this two-line change is to make `sego` able to load its dictionary from HDFS and local filesystem transparently.

I think an alternative solution to support transparency between HDFS and local filesystem is that `sego` load the dictionary from an `io.Reader` interface, so the caller can open whatever file streams and pass it to `sego`. I am all good with either solution.

Thanks,

Yi