### PR TITLE
处理多个字典文件时，避免file对象生命周期延长的问题

### DIFF
--- a/segmenter.go
+++ b/segmenter.go
@@ -43,12 +43,13 @@ func (seg *Segmenter) Dictionary() *Dictionary {
 //	分词文本 频率 词性
 func (seg *Segmenter) LoadDictionary(files string) {
 	seg.dict = NewDictionary()
-	for _, file := range strings.Split(files, ",") {
-		log.Printf("载入sego词典 %s", file)
-		dictFile, err := os.Open(file)
+
+	// 处理字典文件
+	processDictFile := func(fileName string) {
+		dictFile, err := os.Open(fileName)
 		defer dictFile.Close()
 		if err != nil {
-			log.Fatalf("无法载入字典文件 \"%s\" \n", file)
+			log.Fatalf("无法载入字典文件 \"%s\" \n", fileName)
 		}
 
 		reader := bufio.NewReader(dictFile)
@@ -89,6 +90,12 @@ func (seg *Segmenter) LoadDictionary(files string) {
 			token := Token{text: words, frequency: frequency, pos: pos}
 			seg.dict.addToken(token)
 		}
+	}
+
+	for _, file := range strings.Split(files, ",") {
+		log.Printf("载入sego词典 %s", file)
+		// 处理多个字典文件时，避免file对象生命周期延长的问题
+		processDictFile(file)
 	}
 
 	// 计算每个分词的路径值，路径值含义见Token结构体的注释


### PR DESCRIPTION
按照之前的写法，dictFile对象的Close的操作一直会到LoadDictionary函数执行结束的时候才会执行，但是离开了for循环dictFile这个对象就没有存在的必要了，这样defer就会长了dictFile的生命周期，另外如果需要载入多个字典文件的话，会有额外的内存开销，所以现在使用匿名函数处理字典文件，保证每处理完一个字典文件，都会立刻释放资源